### PR TITLE
#166398291 Create endpoint for viewing all posted ads

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "app.js",
     "scripts": {
         "start": "node_modules/.bin/nodemon app.js --exec babel-node",
+        "models": "babel-node ./server/v1/models/ads.js",
         "test": "nyc --reporter=html --reporter=text mocha --exit --require @babel/register ./server/v1 --recursive",
         "coverage": "nyc report --reporter=text-lcov | coveralls"
     },

--- a/server/v1/controllers/ads.js
+++ b/server/v1/controllers/ads.js
@@ -7,6 +7,13 @@ const AdvertHandler = {
             status: 201,
             Data: ad
         });
+    },
+    getAll(req, res) {
+        const ads = Ads.getAllAds();
+        return res.status(200).json({
+            status: 200,
+            Data: ads
+        });
     }
 };
 

--- a/server/v1/models/ads.js
+++ b/server/v1/models/ads.js
@@ -20,5 +20,9 @@ class Ads {
         this.ads.push(newAd);
         return newAd;
     }
+
+    getAllAds() {
+        return this.ads;
+    }
 }
 export default new Ads();

--- a/server/v1/routes/routes.js
+++ b/server/v1/routes/routes.js
@@ -7,5 +7,6 @@ const routes = Router();
 routes.post('/api/v1/auth/signup/', RegisterUser.create);
 // routes.post('/api/v1/auth/signin', RegisterUser.create);
 routes.post('/api/v1/car/', AdvertHandler.create);
+routes.get('/api/v1/cars/', AdvertHandler.getAll);
 
 export default routes;

--- a/server/v1/tests/2-ads.js
+++ b/server/v1/tests/2-ads.js
@@ -61,36 +61,12 @@ describe('Advertisements', () => {
     });
     it('A user should be able to view all posted ads', () => {
         chai.request(app)
-            .get('/api/v1/car')
+            .get('/api/v1/cars/')
             .end((err, res) => {
                 expect(res.body)
                     .to.have.a.status(200)
                     .and.to.be.an('object');
-                expect(res.body.Data).to.have.a.property('id');
-                expect(res.body.Data)
-                    .to.have.a.property('owner')
-                    .and.to.be.a('string');
-                expect(res.body.Data)
-                    .to.have.a.property('email')
-                    .and.to.be.a('string');
-                expect(res.body.Data)
-                    .to.have.a.property('createdOn')
-                    .and.to.be.a('string');
-                expect(res.body.Data)
-                    .to.have.a.property('manufacturer')
-                    .and.to.be.a('string');
-                expect(res.body.Data)
-                    .to.have.a.property('model')
-                    .and.to.be.a('string');
-                expect(res.body.Data)
-                    .to.have.a.property('price')
-                    .and.to.be.a('number');
-                expect(res.body.Data)
-                    .to.have.a.property('state')
-                    .and.to.be.a('string');
-                expect(res.body.Data)
-                    .to.have.a.property('status')
-                    .and.to.be.a('string');
+                expect(res.body.Data).to.be.an('array');
             });
     });
 });


### PR DESCRIPTION
* It creates an endpoint for a user to view all posted ads
#### Description of Task to be completed?
* The `GET /api/v1/cars/` endpoint is created here
#### How should this be manually tested?
* Clone the repository
* Checkout to the `ft-view-posted-all-166398291` branch
* Clone the repo
* Run `npm install` to install package dependencies
* Run `npm test` to run tests
* All the tests should pass
* Run `npm start`
* Run the POST `/api/v1/car/` endpoint to post an ad
* Run the GET `api/v1/cars/` to view all posted ads
* It should return a `status` of `200` with all posted ads
#### What are the relevant pivotal tracker stories?
* [#166398291](https://www.pivotaltracker.com/story/show/166398291)
#### Screenshot
![Screenshot from 2019-06-08 11-26-39](https://user-images.githubusercontent.com/24655101/59144624-f35bba80-89e2-11e9-8255-af90f95efb99.png)