### PR TITLE
#166398284 Create endpoint to delete a specific car Ad

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ language: node_js
 node_js:
     - '10'
 
-install: 
-    - npm ci
+branches:
+    only:
+      - develop
 
 after_success: 
     - npm run coverage
 
+notifications:
+    - email: false

--- a/server/v1/controllers/ads.js
+++ b/server/v1/controllers/ads.js
@@ -21,6 +21,13 @@ const AdvertHandler = {
             status: 200,
             Data: specific
         });
+    },
+    deleteSpecific(req, res) {
+        const deleted = Ads.deleteSpecificAd(parseInt(req.params.id, 10));
+        return res.status(204).json({
+            status: 204,
+            Data: deleted
+        });
     }
 };
 

--- a/server/v1/controllers/ads.js
+++ b/server/v1/controllers/ads.js
@@ -24,9 +24,10 @@ const AdvertHandler = {
     },
     deleteSpecific(req, res) {
         const deleted = Ads.deleteSpecificAd(parseInt(req.params.id, 10));
-        return res.status(204).json({
-            status: 204,
-            Data: deleted
+        return res.status(200).json({
+            status: 200,
+            Data: 'Car Ad successfully deleted',
+            deleted
         });
     }
 };

--- a/server/v1/models/ads.js
+++ b/server/v1/models/ads.js
@@ -29,5 +29,12 @@ class Ads {
         const specific = this.ads.find(advert => advert.id === id);
         return specific;
     }
+
+    deleteSpecificAd(id) {
+        const singleAd = this.getSpecific(id);
+        const index = this.ads.indexOf(singleAd);
+        this.ads.splice(index, 1);
+        return {};
+    }
 }
 export default new Ads();

--- a/server/v1/models/ads.js
+++ b/server/v1/models/ads.js
@@ -34,7 +34,7 @@ class Ads {
         const singleAd = this.getSpecific(id);
         const index = this.ads.indexOf(singleAd);
         this.ads.splice(index, 1);
-        return {};
+        return { id };
     }
 }
 export default new Ads();

--- a/server/v1/routes/routes.js
+++ b/server/v1/routes/routes.js
@@ -9,5 +9,6 @@ routes.post('/api/v1/auth/signup/', RegisterUser.create);
 routes.post('/api/v1/car/', AdvertHandler.create);
 routes.get('/api/v1/cars/', AdvertHandler.getAll);
 routes.get('/api/v1/car/:id', AdvertHandler.viewSpecific);
+routes.delete('/api/v1/car/:id', AdvertHandler.deleteSpecific);
 
 export default routes;

--- a/server/v1/tests/2-ads.js
+++ b/server/v1/tests/2-ads.js
@@ -80,8 +80,8 @@ describe('Advertisements', () => {
         chai.request(app)
             .delete('/api/v1/car/:id')
             .end((err, res) => {
-                expect(res.body).to.have.a.status(204);
-                expect(res.body.Data).to.be.a('string');
+                expect(res).to.have.a.status(200);
+                expect(res.body).to.be.an('object');
             });
     });
 });


### PR DESCRIPTION
* It creates an endpoint for a user to delete a specific car ad
#### Description of Task to be completed?
* The `DELETE /api/v1/car/:id` endpoint is created here
#### How should this be manually tested?
* Clone the repository
* Checkout to the `ft-delete-specific-166398284` branch
* Clone the repo
* Run `npm install` to install package dependencies
* Run `npm test` to run tests
* All the tests should pass
* Run `npm start`
* Run the POST `/api/v1/car/` endpoint to post an ad
* Run the GET `api/v1/cars/` to view all posted ads
* Run the DELETE `api/v1/car/:id` to delete a specific ad
* It should return a `status` of `200` with a message showing the ad id you deleted
* If you run the GET `api/v1/cars/` to view all posted ads, the deleted ad will be missing
#### What are the relevant pivotal tracker stories?
* [#166398284](https://www.pivotaltracker.com/story/show/166398284)
#### Screenshots
![Screenshot from 2019-06-09 11-50-11](https://user-images.githubusercontent.com/24655101/59157098-a1339b80-8aad-11e9-97c2-fbd50ddf5478.png)
![Screenshot from 2019-06-09 11-50-21](https://user-images.githubusercontent.com/24655101/59157101-a55fb900-8aad-11e9-8ec0-d2cac980a03e.png)