### PR TITLE
#166398368 Create failing tests for purchase order

### DIFF
--- a/src/server/v1/tests/3-order.js
+++ b/src/server/v1/tests/3-order.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-undef */
+/* eslint-disable import/no-extraneous-dependencies */
+import chai from 'chai';
+import asserttype from 'chai-asserttype';
+import 'chai/register-expect';
+import chaihttp from 'chai-http';
+import app from '../../../app';
+
+chai.use(chaihttp);
+chai.use(asserttype);
+
+describe('Purchase Order', () => {
+    const order = {
+        Data: {
+            id: 1,
+            carId: 1,
+            createdOn: '01/01/2019',
+            status: 'avalable/sold',
+            price: 4.598,
+            priceOffered: 3.48
+        }
+    };
+    it('A user Should be able to create a purchase order', () => {
+        chai.request(app)
+            .post('/api/v1/car/')
+            .send(order)
+            .end((err, res) => {
+                expect(res.body)
+                    .to.have.a.status(201)
+                    .and.to.be.an('object');
+                expect(res.body.Data).to.have.a.property('id');
+                expect(res.body.Data)
+                    .to.have.a.property('carId')
+                    .and.to.be.a('number');
+                expect(res.body.Data)
+                    .to.have.a.property('createdOn')
+                    .and.to.be.a('string');
+                expect(res.body.Data)
+                    .to.have.a.property('status')
+                    .and.to.be.a('string');
+                expect(res.body.Data)
+                    .to.have.a.property('price')
+                    .and.to.be.a('number');
+                expect(res.body.Data)
+                    .to.have.a.property('priceOffered')
+                    .and.to.be.a('number');
+            });
+    });
+});

--- a/src/server/v1/tests/3-order.js
+++ b/src/server/v1/tests/3-order.js
@@ -22,7 +22,7 @@ describe('Purchase Order', () => {
     };
     it('A user Should be able to create a purchase order', () => {
         chai.request(app)
-            .post('/api/v1/car/')
+            .post('/api/v1/order')
             .send(order)
             .end((err, res) => {
                 expect(res.body)


### PR DESCRIPTION
* It creates a test for making a purchase order
#### Description of Task to be completed?
* The `POST api/v1/order/` endpoint is tested here
#### How should this be manually tested?
* Clone the repository
* Checkout to the `ch-purchase-order-166398368` branch
* Clone the repo
* Run `npm install`
* Run `npm test`
* Six tests should pass with one failing
#### What are the relevant pivotal tracker stories?
* [#166398368](https://www.pivotaltracker.com/story/show/166398368)