### PR TITLE
#166806472 Create Endpoint to view a specific car ad

### DIFF
--- a/src/server/v2/controllers/adsController.js
+++ b/src/server/v2/controllers/adsController.js
@@ -17,7 +17,7 @@ const ads = {
             !req.body.model ||
             !req.body.bodyType
         ) {
-            return res.status(400).send({ message: 'Some values are missing' });
+            return res.status(400).json({ message: 'Some values are missing' });
         }
         const insert = `INSERT INTO cars (owner, createdOn,state, status, price, manufacturer, 
             model, bodyType, description) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) returning *`;
@@ -40,6 +40,18 @@ const ads = {
             });
         } catch (error) {
             return res.status(400).json({ error });
+        }
+    },
+    async viewSpecific(req, res) {
+        const viewAll = `SELECT * FROM cars where id=$1`;
+        try {
+            const { rows } = await db.query(viewAll, [req.params.id]);
+            if (!rows[0]) {
+                return res.status(404).json({ message: 'the ad record was not found' });
+            }
+            return res.status(200).json(rows[0]);
+        } catch (error) {
+            return res.status(400).json(error);
         }
     }
 };

--- a/src/server/v2/routes/routes.js
+++ b/src/server/v2/routes/routes.js
@@ -5,12 +5,12 @@ import orders from '../controllers/orderController';
 
 const routes = Router();
 
-routes.post('/api/v1/auth/signup/', user.signup);
-routes.post('/api/v1/auth/signin', user.login);
-routes.post('/api/v1/car/', ads.create);
-routes.post('/api/v1/order/', orders.create);
-// routes.get('/api/v1/cars/', AdvertHandler.getAll);
-// routes.get('/api/v1/car/:id', AdvertHandler.viewSpecific);
+routes.post('/api/v2/auth/signup/', user.signup);
+routes.post('/api/v2/auth/signin', user.login);
+routes.post('/api/v2/car/', ads.create);
+routes.post('/api/v2/order/', orders.create);
+routes.get('/api/v2/cars/:id', ads.viewSpecific);
+// routes.get('/api/v2/cars/', AdvertHandler.viewAll);
 // routes.delete('/api/v1/car/:id', AdvertHandler.deleteSpecific);
 
 export default routes;


### PR DESCRIPTION
* It creates an endpoint for a user to view a specific car ad
#### Description of Task to be completed?
* The `GET /api/v2/car/:id` endpoint is created here
#### How should this be manually tested?
* Clone the repository
* Checkout to the `ft-view-specific-166806472` branch
* Clone the repo
* Run `npm install` to install package dependencies
* Run `npm test` to run tests
* All the tests should pass
* Run `npm start`
* Run the GET `api/v1/car/:id` to view a specific car ad
* It should return a `status` of `200` with the specific ad you selected
#### What are the relevant pivotal tracker stories?
* [#166398230](https://www.pivotaltracker.com/story/show/166398230)
#### Screenshot
![Screenshot from 2019-06-20 00-16-22](https://user-images.githubusercontent.com/24655101/59802315-70dfce80-92f1-11e9-835c-c2d52f7c8bb2.png)