### PR TITLE
#166398297 Create endpoint to flag posted car ads

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,13 +14,13 @@ app.use(routes);
 app.get('/', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.use((req, res) => {
-	res.status(404).json({
-		status: 404,
-		error: {
-			message: 'The requested url was not found on this server',
-			solution: 'visit / to view the accepted urls'
-		}
-	});
+    res.status(404).json({
+        status: 404,
+        error: {
+            message: 'The requested url was not found on this server',
+            solution: 'visit / to view the accepted urls'
+        }
+    });
 });
 const port = process.env.PORT || 4000;
 app.listen(port, () => console.log(`Server running on port ${port}...`));

--- a/src/server/v2/controllers/flagController.js
+++ b/src/server/v2/controllers/flagController.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-shadow */
+import dotenv from 'dotenv';
+import Joi from '@hapi/joi';
+import '@babel/polyfill';
+import moment from 'moment';
+import db from '../db/index';
+import { flagSchema } from '../middlewares/validations';
+
+dotenv.config();
+
+const flags = {
+    async create(req, res) {
+        const { error } = Joi.validate(req.body, flagSchema);
+        if (error) {
+            return res.status(400).json({
+                status: 400,
+                error: error.details[0].message
+            });
+        }
+        const insert = `INSERT INTO flags (carId, createdOn,reason, description) VALUES ($1, $2, $3, $4) returning *`;
+        const results = [req.body.carId, moment(new Date()), req.body.reason, req.body.description];
+        try {
+            const { rows } = await db.query(insert, results);
+            return res.status(201).json({
+                status: 201,
+                Data: rows[0]
+            });
+        } catch (error) {
+            return res.status(400).json({ error });
+        }
+    }
+};
+
+export default flags;

--- a/src/server/v2/middlewares/validations.js
+++ b/src/server/v2/middlewares/validations.js
@@ -89,3 +89,21 @@ export const orderSchema = Joi.object({
     price: Joi.number().required(),
     priceOffered: Joi.number().required()
 });
+
+export const flagSchema = Joi.object({
+    id: Joi.number(),
+    carId: Joi.number().required(),
+    createdOn: Joi.string()
+        .alphanum()
+        .min(3)
+        .max(200),
+    reason: Joi.string()
+        .alphanum()
+        .min(3)
+        .max(100)
+        .required(),
+    description: Joi.string()
+        .min(3)
+        .max(150)
+        .required()
+});

--- a/src/server/v2/routes/routes.js
+++ b/src/server/v2/routes/routes.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import user from '../controllers/userController';
 import ads from '../controllers/adsController';
 import orders from '../controllers/orderController';
+import flags from '../controllers/flagController';
 import Auth from '../middlewares/auth';
 
 const routes = Router();
@@ -19,6 +20,9 @@ routes.delete('/api/v2/car/:id', tokenVerify, ads.deleteSpecific);
 routes.get('/api/v2/range/cars', tokenVerify, ads.viewUnsoldPriceRange);
 routes.patch('/api/v2/car/:id/status', tokenVerify, ads.markSold);
 routes.patch('/api/v2/car/:id/price', tokenVerify, ads.updatePrice);
+
+// Flagging posted ads routes
+routes.post('/api/v2/flag', tokenVerify, flags.create);
 
 // Purchase order routes
 routes.post('/api/v2/order/', tokenVerify, orders.create);

--- a/src/server/v2/tests/6-docs.js
+++ b/src/server/v2/tests/6-docs.js
@@ -16,7 +16,7 @@ describe('Swagger docs', () => {
             .get('/')
             .end((err, res) => {
                 expect(res.status).to.equal(200);
-                expect(res.body).to.be.a('string');
+                expect(res.body).to.be.an('object');
             });
         done();
     });

--- a/src/server/v2/tests/6-docs.js
+++ b/src/server/v2/tests/6-docs.js
@@ -11,13 +11,13 @@ chai.use(chaihttp);
 chai.use(asserttype);
 
 describe('Swagger docs', () => {
-	it('A user should be able to view swagger docs', done => {
-		chai.request(app)
-			.get('/')
-			.end((err, res) => {
-				expect(res.status).to.equal(200);
-				expect(res.body).to.be.a('string');
-			});
-		done();
-	});
+    it('A user should be able to view swagger docs', done => {
+        chai.request(app)
+            .get('/')
+            .end((err, res) => {
+                expect(res.status).to.equal(200);
+                expect(res.body).to.be.a('string');
+            });
+        done();
+    });
 });


### PR DESCRIPTION
* It creates an endpoint for a user to flag a posted car ad
#### Description of Task to be completed?
* The `POST/api/v2/flag/` endpoint is created here
#### How should this be manually tested?
* Clone the repository
* Checkout to the `ft-flag-fraud-166398297` branch
* Clone the repo
* Run `npm install` to install package dependencies
* Run `npm test` to run tests
* All the tests should pass
* Run `npm start`
* Test the `/api/v2/flag/` request endpoint on postman
* It should return a `status` of `401` since there is no access token provided
* Signup then login to use the access token generated
* On the header tab of postman, use the `x-access-token` key and the paste the token that was generated after login as the value
* It should return a `status` of `201` with the flagged ad id
* Errors are handled properly to prevent app crashing
#### What are the relevant pivotal tracker stories?
* [#166398297](https://www.pivotaltracker.com/story/show/166398297)
#### Screenshot
![Screenshot from 2019-06-27 10-44-10](https://user-images.githubusercontent.com/24655101/60247059-9e67e180-98c8-11e9-98a6-c9d0b252bcf1.png)
![Screenshot from 2019-06-27 10-49-30](https://user-images.githubusercontent.com/24655101/60247444-5c8b6b00-98c9-11e9-8605-999dbee452c0.png)
