### PR TITLE
#166952377 Create endpoint to view all used unsold car ads

### DIFF
--- a/src/server/v2/controllers/adsController.js
+++ b/src/server/v2/controllers/adsController.js
@@ -113,6 +113,26 @@ const ads = {
             return res.status(400).json({ status: 400, error });
         }
     },
+    async viewUnsoldUsed(req, res) {
+        const value = req.query.status;
+        const value2 = req.query.state;
+        const viewUnsoldUsed = `SELECT * from cars WHERE status = $1 AND state = $2`;
+        try {
+            const { rows } = await db.query(viewUnsoldUsed, [value, value2]);
+            if (!rows[0]) {
+                return res.status(404).send({
+                    status: 404,
+                    error: 'All cars have been sold, please try again'
+                });
+            }
+            return res.status(200).json({
+                status: 200,
+                Data: rows
+            });
+        } catch (error) {
+            return res.status(400).json({ status: 400, error });
+        }
+    },
     async viewUnsoldPriceRange(req, res) {
         const { minPrice, maxPrice } = req.query;
         const min = Math.min(minPrice, maxPrice);

--- a/src/server/v2/routes/routes.js
+++ b/src/server/v2/routes/routes.js
@@ -15,6 +15,7 @@ routes.post('/api/v2/auth/signin', user.login);
 routes.post('/api/v2/car/', tokenVerify, ads.create);
 routes.get('/api/v2/cars/:id', tokenVerify, ads.viewSpecific);
 routes.get('/api/v2/status/cars', tokenVerify, ads.viewUnsold);
+routes.get('/api/v2/status/used', tokenVerify, ads.viewUnsoldUsed);
 routes.get('/api/v2/cars', tokenVerify, ads.viewAll);
 routes.delete('/api/v2/car/:id', tokenVerify, ads.deleteSpecific);
 routes.get('/api/v2/range/cars', tokenVerify, ads.viewUnsoldPriceRange);


### PR DESCRIPTION
* It creates an endpoint for a user to view all used unsold car ads
#### Description of Task to be completed?
* The `GET /car?status=available&state=used/` endpoint is created here
#### How should this be manually tested?
* Clone the repository
* Checkout to the `ft-view-all-used-unsold-166952377` branch
* Clone the repo
* Run `npm install` to install package dependencies
* Run `npm test` to run tests
* All the tests should pass
* Run `npm start`
* Test the `/api/v2/status/used?status=available&state=used` request endpoint on postman
* It should return a `status` of `401` since there is no access token provided
* Signup then login to use the access token generated
* On the header tab of postman, use the `x-access-token` key and the paste the token that was generated after login as the value
* It should return a `status` of `200
` with all the used unsold car ads
* Errors are handled properly to prevent app crashing
#### What are the relevant pivotal tracker stories?
* [#166952377](https://www.pivotaltracker.com/story/show/166952377)
#### Screenshot
![Screenshot from 2019-06-28 10-06-43](https://user-images.githubusercontent.com/24655101/60324117-8e193a80-998c-11e9-9e7f-aaadba78071e.png)